### PR TITLE
Fix static hintText when using hintTextColor

### DIFF
--- a/Classes/TiUITextField+Extended.m
+++ b/Classes/TiUITextField+Extended.m
@@ -10,18 +10,7 @@
 
 - (void) setHintTextColor_:(id)color
 {
-    TiColor *newColor = [TiUtils colorValue:color];
-    self.textWidgetView.attributedPlaceholder = [[NSAttributedString alloc] initWithString:@"text" attributes:@{NSForegroundColorAttributeName: [TiUtils barColorForColor:newColor]}];
-    
-    /*
-	if([TiUtils isIOS6OrGreater]){
-        self.textWidgetView.attributedPlaceholder = [[NSAttributedString alloc] initWithString:@"text" attributes:@{NSForegroundColorAttributeName: newColor}];
-    } else {
-        [self.textWidgetView setValue:[newColor _color] forKeyPath:@"_placeholderLabel.textColor"];
-    }
-    
-*/    
-    //[self.textWidgetView setValue:[color _color] forKeyPath:@"_placeholderLabel.textColor"];
+    self.textWidgetView.attributedPlaceholder = [[NSAttributedString alloc] initWithString:[TiUtils stringValue:[[self proxy] valueForKey:@"hintText"]] attributes:@{NSForegroundColorAttributeName: [[TiUtils colorValue:value] _color]}];
 }
 
 


### PR DESCRIPTION
Issue: https://github.com/viezel/NappUI/issues/55

This PR grabs the `hintText` from it's proxy instead of using the static "text" value.
